### PR TITLE
Add HAVE_MMAP=0 flag

### DIFF
--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -43,6 +43,7 @@ RUN git clone https://github.com/SDL-mirror/SDL.git \
     && mkdir build; cd build \
     && CFLAGS="-O3 -fPIC" \
     cmake ../ -G Ninja \
+        -DHAVE_MMAP=0 \
         -DSDL_SHARED=0 \
         -DSDL_AUDIO=0 \
         -DVIDEO_VIVANTE=ON \


### PR DESCRIPTION
Add HAVE_MMAP=0 flag, because `totalcross` is broken in some arm64 systems.